### PR TITLE
Code Review: Document the generated content in the developer website (#10984)

### DIFF
--- a/SelectionChanged Example.sketchplugin/Contents/Sketch/selection-changed.js
+++ b/SelectionChanged Example.sketchplugin/Contents/Sketch/selection-changed.js
@@ -1,9 +1,7 @@
-// SelectionChanged, by Sam Deane — Source code available at [GitHub](https://github.com/BohemianCoding/plugins.examples.selection-changed)
+// Selection Changed, by Sam Deane — Source code available at [GitHub](https://github.com/BohemianCoding/plugins.examples.selection-changed)
 //
 // This example plugin illustrates how to listen for the SelectionChanged action, and to
 // do something whenever the user changes the selection.
-//
-// It uses the new Action API in Sketch 3.8.
 
 //
 // ## Layout


### PR DESCRIPTION
Code review for Document the generated content in the developer website (#10984):

> It makes sense to mention somewhere that the API documentation and the plugin example documentation are both auto-generated using scripts.
> 
> It might also make sense to re-organise the scripts so that they place all of the auto-generated content into a root `_generated` folder.
> 
> We can then tell everyone "don't hand-edit anything in _generated, there's no point".


Connect to BohemianCoding/Sketch#10984.