### PR TITLE
Fix typo in sample code

### DIFF
--- a/SelectionChanged Example.sketchplugin/Contents/Sketch/selection-changed.js
+++ b/SelectionChanged Example.sketchplugin/Contents/Sketch/selection-changed.js
@@ -38,7 +38,7 @@
 //   "authorEmail" : "sam@bohemiancoding.com",
 //   "commands" : [
 //     {
-//       "script" : "script.js",
+//       "script" : "selection-changed.js",
 //       "handlers" : {
 //         "actions" : {
 //            "SelectionChanged.finish" : "onSelectionChanged",


### PR DESCRIPTION
While reading through http://developer.sketchapp.com/examples/plugins/selection-changed/ I was a bit confused by the mention of `script.js` which wasn't anywhere in the example. After running it myself my guess is that this might have been a typo from an older version of the demo.